### PR TITLE
fix: handle objects with missing properties

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/jsonschematomappings/__init__.py
+++ b/jsonschematomappings/__init__.py
@@ -30,6 +30,7 @@ TYPE_MAP = {
     "number": "float",
     "integer": "long",
     "string": "keyword",
+    "object": "object",
 }
 
 
@@ -204,7 +205,7 @@ class JSONSchemaToMappings:
                 )
 
             # object type (dict) - recurse
-            if t == JS_OBJECT_TYPE:
+            if t == JS_OBJECT_TYPE and JS_PROPERTIES_KEY in o[k]:
                 converted[k] = {
                     OS_PROPERTIES_KEY: self._convert_property(o=o[k][JS_PROPERTIES_KEY])
                 }

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,2 @@
+setuptools>=65.5.1
 fastjsonschema>=2.16.2,<3

--- a/tests/test_jsonschematomappings.py
+++ b/tests/test_jsonschematomappings.py
@@ -262,6 +262,10 @@ def test__update_dict(d, u, r):
             {"name": {"properties": {"subprop": {"type": "keyword"}}}},
         ),
         (
+            {"name": {"type": "object"}},
+            {"name": {"type": "object"}},
+        ),
+        (
             {
                 "name": {
                     "type": "array",


### PR DESCRIPTION
This MR adds handling for objects without defined properties. If the properties key is missing, it will simple store the fields as "type": "object" in the mapping.